### PR TITLE
fix: background not displaying

### DIFF
--- a/classes/main.php
+++ b/classes/main.php
@@ -31,7 +31,7 @@ class Main {
 		$css = "\n<style>";
 		$css .= "\n\t /** BEA - Beautiful Flexible : dynamic images */";
 		foreach ( $images as $layout_key => $image_url ) {
-			$css .= sprintf( "\n\t .acf-fc-popup ul li a[data-layout=%s]{ background-image: url(\"%s\"); }", $layout_key, $image_url );
+			$css .= sprintf( "\n\t .acf-fc-popup ul li a[data-layout=\"%s\"]{ background-image: url(\"%s\"); }", $layout_key, $image_url );
 		}
 		$css .= "\n</style>\n";
 


### PR DESCRIPTION
I added quotes on generated CSS so it can works on layouts with name starting with a number.

    a[data-layout=2columns] 

Is not valid wherease

    a[data-layout="2columns"]

is